### PR TITLE
Add helm init to fix helm dependency update

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -50,6 +50,8 @@ class HelmRenderEngine extends RenderEngine {
                 silent: isSilent
             };
             var dependencyArgs = this.getDependencyArgs(chartPath);
+            console.log("Running helm init..");
+            yield utilities.execCommand(helmPath, ['init', '--client-only'], options);
             console.log("Running helm dependency update command..");
             yield utilities.execCommand(helmPath, dependencyArgs, options);
             console.log("Getting helm verion..");

--- a/src/run.ts
+++ b/src/run.ts
@@ -37,6 +37,9 @@ class HelmRenderEngine extends RenderEngine {
 
         var dependencyArgs = this.getDependencyArgs(chartPath);
 
+        console.log("Running helm init..");
+        await utilities.execCommand(helmPath, ['init', '--client-only'], options);
+
         console.log("Running helm dependency update command..");
         await utilities.execCommand(helmPath, dependencyArgs, options);
 


### PR DESCRIPTION
When having a chart with dependencies against official charts, we need to run helm init first.