### PR TITLE
Updating helm init command with new stable repo path

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -57,7 +57,7 @@ class HelmRenderEngine extends RenderEngine {
             yield this.isHelmV3(helmPath).then(() => { isV3 = true; }).catch(() => { isV3 = false; });
             try {
                 if (!isV3) {
-                    yield utilities.execCommand(helmPath, ['init', '--client-only'], options);
+                    yield utilities.execCommand(helmPath, ['init', '--client-only', '--stable-repo-url', 'https://charts.helm.sh/stable'], options);
                 }
             }
             catch (ex) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -46,7 +46,7 @@ class HelmRenderEngine extends RenderEngine {
         
         try {
             if (!isV3) {
-                await utilities.execCommand(helmPath, ['init', '--client-only'], options);
+                await utilities.execCommand(helmPath, ['init', '--client-only', '--stable-repo-url', 'https://charts.helm.sh/stable'], options);
             }
         } catch (ex) {
             core.warning(util.format('Could not run helm init command: ', ex));


### PR DESCRIPTION
Helm init command fails for versions < v2.17.0 because the stable repo path has been updated. It works if the command is patched with the latest path.