### PR TITLE
kubectl incorrect path bug fix, closes #28

### DIFF
--- a/__tests__/kubectl-util.test.ts
+++ b/__tests__/kubectl-util.test.ts
@@ -166,7 +166,7 @@ describe('Testing all funcitons in kubectl-util file.', () => {
         jest.spyOn(toolCache, 'find').mockReturnValue('pathToKubectl');
         jest.spyOn(os, 'type').mockReturnValue('Windows_NT');
 
-        expect(await kubectlUtil.getKubectlPath()).toBe('pathToKubectl');
+        expect(await kubectlUtil.getKubectlPath()).toBe(path.join('pathToKubectl', 'kubectl.exe'));
         expect(core.getInput).toBeCalledWith('kubectl-version', {required: false});
         expect(toolCache.find).toBeCalledWith('kubectl', 'v2.0.0');
     });

--- a/lib/kubectl-util.js
+++ b/lib/kubectl-util.js
@@ -64,7 +64,7 @@ function downloadKubectl(version) {
             cachedToolpath = yield toolCache.cacheFile(kubectlDownloadPath, kubectlToolName + utilities_1.getExecutableExtension(), kubectlToolName, version);
         }
         const kubectlPath = path.join(cachedToolpath, kubectlToolName + utilities_1.getExecutableExtension());
-        fs.chmodSync(kubectlPath, '777');
+        fs.chmodSync(kubectlPath, "777");
         return kubectlPath;
     });
 }
@@ -75,7 +75,8 @@ function getKubectlPath() {
         if (core.getInput('kubectl-version', { required: false })) {
             var version = core.getInput('kubectl-version', { required: false });
             if (!!version && version != "latest") {
-                kubectlPath = toolCache.find('kubectl', version);
+                const cachedToolPath = toolCache.find('kubectl', version);
+                kubectlPath = path.join(cachedToolPath, kubectlToolName + utilities_1.getExecutableExtension());
             }
             if (!kubectlPath) {
                 kubectlPath = yield installKubectl(version);

--- a/lib/kubectl-util.js
+++ b/lib/kubectl-util.js
@@ -64,7 +64,7 @@ function downloadKubectl(version) {
             cachedToolpath = yield toolCache.cacheFile(kubectlDownloadPath, kubectlToolName + utilities_1.getExecutableExtension(), kubectlToolName, version);
         }
         const kubectlPath = path.join(cachedToolpath, kubectlToolName + utilities_1.getExecutableExtension());
-        fs.chmodSync(kubectlPath, "777");
+        fs.chmodSync(kubectlPath, '777');
         return kubectlPath;
     });
 }

--- a/src/kubectl-util.ts
+++ b/src/kubectl-util.ts
@@ -58,7 +58,7 @@ export async function downloadKubectl(version: string): Promise<string> {
     }
 
     const kubectlPath = path.join(cachedToolpath, kubectlToolName + getExecutableExtension());
-    fs.chmodSync(kubectlPath, '777');
+    fs.chmodSync(kubectlPath, "777");
     return kubectlPath;
 }
 
@@ -68,7 +68,8 @@ export async function getKubectlPath() {
     if (core.getInput('kubectl-version', { required: false })) {
         var version = core.getInput('kubectl-version', { required: false });
         if ( !!version && version != "latest" ){
-            kubectlPath = toolCache.find('kubectl', version);
+            const cachedToolPath = toolCache.find('kubectl', version);
+            kubectlPath = path.join(cachedToolPath, kubectlToolName + getExecutableExtension())
         }
         
         if (!kubectlPath) {

--- a/src/kubectl-util.ts
+++ b/src/kubectl-util.ts
@@ -58,7 +58,7 @@ export async function downloadKubectl(version: string): Promise<string> {
     }
 
     const kubectlPath = path.join(cachedToolpath, kubectlToolName + getExecutableExtension());
-    fs.chmodSync(kubectlPath, "777");
+    fs.chmodSync(kubectlPath, '777');
     return kubectlPath;
 }
 


### PR DESCRIPTION
Fixed the incorrect path bug detailed here: https://github.com/Azure/k8s-bake/issues/28.

The kubectl tool name was not being appended when the version was already cached and didn't need to be downloaded.