### PR TITLE
Update Node  and Kompose versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ outputs:
 branding:
    color: 'green' # optional, decorates the entry in the GitHub Marketplace
 runs:
-   using: 'node16'
+   using: 'node20'
    main: 'lib/index.js'

--- a/src/kompose-util.test.ts
+++ b/src/kompose-util.test.ts
@@ -86,7 +86,7 @@ describe('Testing all funcitons in kompose-util file.', () => {
          path.join('pathToCachedTool', 'kompose.exe')
       )
       expect(core.getInput).toBeCalledWith('kompose-version', {required: false})
-      expect(toolCache.find).toBeCalledWith('kompose', 'v1.18.0')
+      expect(toolCache.find).toBeCalledWith('kompose', 'v1.32.0')
    })
 
    test('getKomposePath() - return path to specified version kompose from toolCache', async () => {

--- a/src/kompose-util.ts
+++ b/src/kompose-util.ts
@@ -15,7 +15,7 @@ import {
 } from './utilities'
 
 const komposeToolName = 'kompose'
-const stableKomposeVersion = 'v1.18.0'
+const defaultStableKomposeVersion = 'v1.32.0'
 
 export async function getKomposePath() {
    let komposePath = ''
@@ -52,7 +52,7 @@ export async function getKomposePath() {
 }
 
 export async function downloadKompose(
-   version: string = stableKomposeVersion
+   version: string = defaultStableKomposeVersion
 ): Promise<string> {
    let cachedToolpath = toolCache.find(komposeToolName, version)
    if (!cachedToolpath) {
@@ -69,7 +69,7 @@ export async function downloadKompose(
 
 export async function installKompose(version: string) {
    if (isEqual(version, LATEST)) {
-      version = stableKomposeVersion
+      version = defaultStableKomposeVersion
    }
    core.debug(util.format('Downloading kompose version %s', version))
    return await downloadKompose(version)


### PR DESCRIPTION
Latest Kompose version can be found here: https://github.com/kubernetes/kompose/releases/

As of this writing, it's `1.32.0` hence why I targetted that.
![image](https://github.com/Azure/k8s-bake/assets/20101933/16563b29-27a4-4baf-966f-d3b22ec1bd31)
