### PR TITLE
Adding a check for cached version #98

### DIFF
--- a/src/kubectl-util.test.ts
+++ b/src/kubectl-util.test.ts
@@ -170,12 +170,15 @@ describe('Testing all functions in kubectl-util file.', () => {
       jest.spyOn(core, 'getInput').mockReturnValue('v1.15.0')
       jest.spyOn(toolCache, 'find').mockReturnValue(undefined)
       jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
+
+      const mockedInstallPath = 'mocked/path/to/kubectl.exe'
+
       jest
          .spyOn(kubectlUtil, 'installKubectl')
-         .mockResolvedValue('mocked/path/to/kubectl.exe') 
+         .mockResolvedValue(mockedInstallPath)
 
       const result = await kubectlUtil.getKubectlPath()
 
-      expect(result).toBe('mocked/path/to/kubectl.exe')
+      expect(result).toBe(mockedInstallPath)
    })
 })

--- a/src/kubectl-util.test.ts
+++ b/src/kubectl-util.test.ts
@@ -8,7 +8,6 @@ import * as io from '@actions/io'
 import * as utils from './utilities'
 
 describe('Testing all functions in kubectl-util file.', () => {
-
    afterEach(() => jest.restoreAllMocks())
    test('downloadKubectl() - download kubectl, add it to toolCache and return path to it', async () => {
       jest.spyOn(toolCache, 'find').mockReturnValue('')
@@ -32,6 +31,7 @@ describe('Testing all functions in kubectl-util file.', () => {
 
    test('downloadKubectl() - throw DownloadKubectlFailed error when unable to download kubectl', async () => {
       jest.spyOn(toolCache, 'find').mockReturnValue('')
+      jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
       jest
          .spyOn(toolCache, 'downloadTool')
          .mockRejectedValue('Unable to download kubectl.')

--- a/src/kubectl-util.test.ts
+++ b/src/kubectl-util.test.ts
@@ -170,8 +170,12 @@ describe('Testing all functions in kubectl-util file.', () => {
       jest.spyOn(core, 'getInput').mockReturnValue('v1.15.0')
       jest.spyOn(toolCache, 'find').mockReturnValue(undefined)
       jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
-
-      const expectedPath = await kubectlUtil.installKubectl('v1.15.0')
+      jest
+         .spyOn(toolCache, 'downloadTool')
+         .mockResolvedValue('mockedDownloadPath')
+      jest.spyOn(toolCache, 'cacheFile').mockResolvedValue('mockedCachePath')
+      jest.spyOn(fs, 'chmodSync').mockImplementation()
+      const expectedPath = path.join('mockedCachePath', 'kubectl.exe')
 
       const result = await kubectlUtil.getKubectlPath()
 

--- a/src/kubectl-util.test.ts
+++ b/src/kubectl-util.test.ts
@@ -8,6 +8,8 @@ import * as io from '@actions/io'
 import * as utils from './utilities'
 
 describe('Testing all functions in kubectl-util file.', () => {
+
+   afterEach(() => jest.restoreAllMocks())
    test('downloadKubectl() - download kubectl, add it to toolCache and return path to it', async () => {
       jest.spyOn(toolCache, 'find').mockReturnValue('')
       jest.spyOn(toolCache, 'downloadTool').mockResolvedValue('pathToTool')
@@ -165,8 +167,6 @@ describe('Testing all functions in kubectl-util file.', () => {
    })
 
    test('getKubectlPath() - installs kubectl if version is provided but not cached', async () => {
-      jest.restoreAllMocks()
-
       jest.spyOn(core, 'getInput').mockReturnValue('v1.15.0')
       jest.spyOn(toolCache, 'find').mockReturnValue(undefined)
       jest.spyOn(os, 'type').mockReturnValue('Windows_NT')

--- a/src/kubectl-util.test.ts
+++ b/src/kubectl-util.test.ts
@@ -171,14 +171,10 @@ describe('Testing all functions in kubectl-util file.', () => {
       jest.spyOn(toolCache, 'find').mockReturnValue(undefined)
       jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
 
-      const mockedInstallPath = 'mocked/path/to/kubectl.exe'
-
-      jest
-         .spyOn(kubectlUtil, 'installKubectl')
-         .mockResolvedValue(mockedInstallPath)
+      const expectedPath = await kubectlUtil.installKubectl('v1.15.0')
 
       const result = await kubectlUtil.getKubectlPath()
 
-      expect(result).toBe(mockedInstallPath)
+      expect(result).toBe(expectedPath)
    })
 })

--- a/src/kubectl-util.test.ts
+++ b/src/kubectl-util.test.ts
@@ -163,4 +163,18 @@ describe('Testing all functions in kubectl-util file.', () => {
       })
       expect(toolCache.find).toHaveBeenCalledWith('kubectl', 'v2.0.0')
    })
+
+   test('getKubectlPath() - installs kubectl if version is provided but not cached', async () => {
+      jest.restoreAllMocks()
+
+      jest.spyOn(core, 'getInput').mockReturnValue('v1.15.0')
+      jest.spyOn(toolCache, 'find').mockReturnValue(undefined)
+      jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
+
+      const expectedPath = await kubectlUtil.installKubectl('v1.15.0')
+
+      const result = await kubectlUtil.getKubectlPath()
+
+      expect(result).toBe(expectedPath)
+   })
 })

--- a/src/kubectl-util.test.ts
+++ b/src/kubectl-util.test.ts
@@ -170,11 +170,12 @@ describe('Testing all functions in kubectl-util file.', () => {
       jest.spyOn(core, 'getInput').mockReturnValue('v1.15.0')
       jest.spyOn(toolCache, 'find').mockReturnValue(undefined)
       jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
-
-      const expectedPath = await kubectlUtil.installKubectl('v1.15.0')
+      jest
+         .spyOn(kubectlUtil, 'installKubectl')
+         .mockResolvedValue('mocked/path/to/kubectl.exe') 
 
       const result = await kubectlUtil.getKubectlPath()
 
-      expect(result).toBe(expectedPath)
+      expect(result).toBe('mocked/path/to/kubectl.exe')
    })
 })

--- a/src/kubectl-util.ts
+++ b/src/kubectl-util.ts
@@ -41,10 +41,12 @@ export async function getKubectlPath() {
    if (version) {
       if (!!version && version != LATEST) {
          const cachedToolPath = toolCache.find(kubectlToolName, version)
-         kubectlPath = path.join(
-            cachedToolPath,
-            kubectlToolName + getExecutableExtension()
-         )
+         if (cachedToolPath) {
+            kubectlPath = path.join(
+               cachedToolPath,
+               kubectlToolName + getExecutableExtension()
+            )
+         }
       }
 
       if (!kubectlPath) {


### PR DESCRIPTION
I am addressing issue https://github.com/Azure/k8s-bake/issues/98.

- Added a check for the edge case where the version requested was not cached, therefore cachetoolPath was undefined
- Added appropriate tests for this.