### PR TITLE
added warning for mistaken separators#97

### DIFF
--- a/src/bake.test.ts
+++ b/src/bake.test.ts
@@ -31,6 +31,8 @@ jest.mock('@actions/exec/lib/toolrunner', () => {
 })
 
 describe('Test all functions in run file', () => {
+   afterEach(() => jest.restoreAllMocks())
+
    test("KustomizeRenderEngine() - throw error if kubectl doesn't meet required version", async () => {
       jest
          .spyOn(kubectlUtil, 'getKubectlPath')
@@ -348,9 +350,10 @@ describe('Test all functions in run file', () => {
          path.join('tempDirPath', 'baked-template-12345678.yaml')
       )
       expect(warnSpy).toHaveBeenCalledWith(
-         expect.stringContaining("Did you mean to use ':' instead?")
+         expect.stringContaining(
+            "is missing a ':' separator. Please use the format key:value."
+         )
       )
-      warnSpy.mockRestore()
    })
 
    test('HelmRenderEngine() - single additional argument', async () => {

--- a/src/bake.test.ts
+++ b/src/bake.test.ts
@@ -302,6 +302,7 @@ describe('Test all functions in run file', () => {
       jest.spyOn(helmUtil, 'getHelmPath').mockResolvedValue('pathToHelm')
       jest.spyOn(core, 'getInput').mockImplementation((inputName, options) => {
          if (inputName == 'helmChart') return 'pathToHelmChart'
+         if (inputName == 'overrides') return 'replicas=2'
          if (inputName == 'releaseName') return 'releaseName'
          if (inputName == 'renderEngine') return 'helm'
       })
@@ -312,6 +313,7 @@ describe('Test all functions in run file', () => {
       jest.spyOn(fs, 'writeFileSync').mockImplementation()
       jest.spyOn(utils, 'getCurrentTime').mockReturnValue(12345678)
       jest.spyOn(core, 'setOutput').mockImplementation()
+      const warnSpy = jest.spyOn(core, 'warning').mockImplementation()
 
       const execResult = {
          stdout: 'test output'
@@ -345,6 +347,10 @@ describe('Test all functions in run file', () => {
          'manifestsBundle',
          path.join('tempDirPath', 'baked-template-12345678.yaml')
       )
+      expect(warnSpy).toHaveBeenCalledWith(
+         expect.stringContaining("Did you mean to use ':' instead?")
+      )
+      warnSpy.mockRestore()
    })
 
    test('HelmRenderEngine() - single additional argument', async () => {

--- a/src/bake.test.ts
+++ b/src/bake.test.ts
@@ -249,6 +249,11 @@ describe('Test all functions in run file', () => {
       process.env['RUNNER_TEMP'] = 'tempDir'
       jest.spyOn(utils, 'getCurrentTime').mockReturnValue(12345678)
       jest.spyOn(core, 'setOutput').mockImplementation()
+      jest.spyOn(utils, 'execCommand').mockResolvedValue({
+         code: 0,
+         stdout: 'kompose output',
+         stderr: ''
+      } as any)
 
       expect(await new KomposeRenderEngine().bake(true)).toBeUndefined()
       expect(komposeUtil.getKomposePath).toHaveBeenCalled()

--- a/src/bake.ts
+++ b/src/bake.ts
@@ -82,14 +82,15 @@ export class HelmRenderEngine extends RenderEngine {
    private getOverrideValues(overrides: string[]) {
       const overrideValues: NameValuePair[] = []
       overrides.forEach((arg) => {
+         if (!arg.includes(':')) {
+            core.warning(
+               `Override "${arg}" is missing a ':' separator. Please use the format key:value.`
+            )
+            return
+         }
          const overrideInput = arg.split(':')
          const overrideName = overrideInput[0]
          const overrideValue = overrideInput.slice(1).join(':').trim()
-         if (overrideValue === '' && overrideName.includes('=')) {
-            core.warning(
-               `It looks like you used '=' as a separator in "${arg}". Did you mean to use ':' instead?`
-            )
-         }
          overrideValues.push({
             name: overrideName,
             value: overrideValue

--- a/src/bake.ts
+++ b/src/bake.ts
@@ -85,6 +85,11 @@ export class HelmRenderEngine extends RenderEngine {
          const overrideInput = arg.split(':')
          const overrideName = overrideInput[0]
          const overrideValue = overrideInput.slice(1).join(':').trim()
+         if (overrideValue === '' && overrideName.includes('=')) {
+            core.warning(
+               `It looks like you used '=' as a separator in "${arg}". Did you mean to use ':' instead?`
+            )
+         }
          overrideValues.push({
             name: overrideName,
             value: overrideValue


### PR DESCRIPTION
- Users said that they sometimes use replicas=2 instead of replicas:2 leading to an error without explanation. Added a warning for when this is spotted adjusted tests as necessary.