### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Azure/aks-atlanta
+* @Azure/cloud-native-github-action-owners


### PR DESCRIPTION
the old codeowners refers to the deprecated aks-atlanta team.

this is the new, correct team to require codeowner approval