### PR TITLE
chore(release): bump version to 3.0.2 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.0.2 - 2025-08-06]
+
+### Changed
+
+- #168 A[dding a check for cached version](https://github.com/Azure/k8s-bake/pull/168)
+- #163 [Add husky pre-commit hook.](https://github.com/Azure/k8s-bake/pull/163)
+- #160 [Fix the --no-bin-links break.](https://github.com/Azure/k8s-bake/pull/160)
+- #151 [Fix/jest type test](https://github.com/Azure/k8s-bake/pull/151)
+- #128 [Security: remove updated action and fix prettier](https://github.com/Azure/k8s-bake/pull/128)
+- #127 [Add code quality Analysis and pin SHA for GH](https://github.com/Azure/k8s-bake/pull/127)
+
 ## [3.0.1] - 2024-09-06
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "k8sbake",
-   "version": "3.0.0",
+   "version": "3.0.2",
    "lockfileVersion": 2,
    "requires": true,
    "packages": {
       "": {
          "name": "k8sbake",
-         "version": "3.0.0",
+         "version": "3.0.2",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "k8sbake",
-   "version": "3.0.0",
+   "version": "3.0.2",
    "description": "Kubernetes Bake",
    "author": "Anumita Shenoy",
    "license": "MIT",


### PR DESCRIPTION
This pull request updates the version of the project to `3.0.2` and adds a new changelog entry summarizing recent fixes and improvements. The main changes are related to versioning and documentation.

Versioning and documentation:

* Updated the version in `package.json` from `3.0.0` to `3.0.2` to reflect the new release.
* Added a new `3.0.2` section to `CHANGELOG.md` listing recent pull requests and changes, including bug fixes, security improvements, and code quality enhancements.