### PR TITLE
switch to current k8s download URLs

### DIFF
--- a/src/kubectl-util.test.ts
+++ b/src/kubectl-util.test.ts
@@ -38,7 +38,7 @@ describe('Testing all functions in kubectl-util file.', () => {
       )
 
       await expect(kubectlUtil.downloadKubectl('v1.15.0')).rejects.toThrow(
-         'Failed to download the kubectl from https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/windows/amd64/kubectl.exe.  Error: Unable to download kubectl.'
+         'Failed to download the kubectl from https://dl.k8s.io/v1.15.0/bin/windows/amd64/kubectl.exe.  Error: Unable to download kubectl.'
       )
       expect(toolCache.find).toHaveBeenCalledWith('kubectl', 'v1.15.0')
       expect(toolCache.downloadTool).toHaveBeenCalled()

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -149,7 +149,7 @@ describe('Test all functions in utilities file', () => {
       vi.spyOn(os, 'type').mockReturnValue('Linux')
       vi.spyOn(os, 'arch').mockReturnValue('x64')
       const kubectlLinuxUrl =
-         'https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl'
+         'https://dl.k8s.io/v1.15.0/bin/linux/amd64/kubectl'
 
       expect(utils.getDownloadUrl('kubectl', 'v1.15.0')).toBe(kubectlLinuxUrl)
       expect(os.type).toHaveBeenCalled()
@@ -160,7 +160,7 @@ describe('Test all functions in utilities file', () => {
       vi.spyOn(os, 'type').mockReturnValue('Linux')
       vi.spyOn(os, 'arch').mockReturnValue('arm64')
       const kubectlLinuxUrl =
-         'https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/arm64/kubectl'
+         'https://dl.k8s.io/v1.15.0/bin/linux/arm64/kubectl'
 
       expect(utils.getDownloadUrl('kubectl', 'v1.15.0')).toBe(kubectlLinuxUrl)
       expect(os.type).toHaveBeenCalled()
@@ -170,7 +170,7 @@ describe('Test all functions in utilities file', () => {
    test('getDownloadUrl() - return the URL to download kubectl for Darwin', () => {
       vi.spyOn(os, 'type').mockReturnValue('Darwin')
       const kubectlDarwinUrl =
-         'https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/darwin/amd64/kubectl'
+         'https://dl.k8s.io/v1.15.0/bin/darwin/amd64/kubectl'
 
       expect(utils.getDownloadUrl('kubectl', 'v1.15.0')).toBe(kubectlDarwinUrl)
       expect(os.type).toHaveBeenCalled()
@@ -180,7 +180,7 @@ describe('Test all functions in utilities file', () => {
       vi.spyOn(os, 'type').mockReturnValue('Windows_NT')
 
       const kubectlWindowsUrl =
-         'https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/windows/amd64/kubectl.exe'
+         'https://dl.k8s.io/v1.15.0/bin/windows/amd64/kubectl.exe'
       expect(utils.getDownloadUrl('kubectl', 'v1.15.0')).toBe(kubectlWindowsUrl)
       expect(os.type).toHaveBeenCalled()
    })

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -147,8 +147,7 @@ const defaultStableHelmVersion = 'v3.19.3'
 const defaultStableKubectlVersion = 'v1.34.3'
 
 const stableVersionUrls: Record<string, string> = {
-   kubectl:
-      'https://storage.googleapis.com/kubernetes-release/release/stable.txt',
+   kubectl: 'https://dl.k8s.io/release/stable.txt',
    helm: 'https://api.github.com/repos/helm/helm/releases/latest'
 }
 
@@ -157,29 +156,25 @@ const downloadLinks: Record<string, Record<string, string>> = {
       helm: 'https://get.helm.sh/helm-%s-linux-amd64.zip',
       kompose:
          'https://github.com/kubernetes/kompose/releases/download/%s/kompose-linux-amd64',
-      kubectl:
-         'https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl'
+      kubectl: 'https://dl.k8s.io/%s/bin/linux/amd64/kubectl'
    },
    Linux_arm64: {
       helm: 'https://get.helm.sh/helm-%s-linux-arm64.zip',
       kompose:
          'https://github.com/kubernetes/kompose/releases/download/%s/kompose-linux-arm64',
-      kubectl:
-         'https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/arm64/kubectl'
+      kubectl: 'https://dl.k8s.io/%s/bin/linux/arm64/kubectl'
    },
    Darwin: {
       helm: 'https://get.helm.sh/helm-%s-darwin-amd64.zip',
       kompose:
          'https://github.com/kubernetes/kompose/releases/download/%s/kompose-darwin-amd64',
-      kubectl:
-         'https://storage.googleapis.com/kubernetes-release/release/%s/bin/darwin/amd64/kubectl'
+      kubectl: 'https://dl.k8s.io/%s/bin/darwin/amd64/kubectl'
    },
    Windows_NT: {
       helm: 'https://get.helm.sh/helm-%s-windows-amd64.zip',
       kompose:
          'https://github.com/kubernetes/kompose/releases/download/%s/kompose-windows-amd64.exe',
-      kubectl:
-         'https://storage.googleapis.com/kubernetes-release/release/%s/bin/windows/amd64/kubectl.exe'
+      kubectl: 'https://dl.k8s.io/%s/bin/windows/amd64/kubectl.exe'
    }
 }
 


### PR DESCRIPTION
Kubernetes switched their download repositories away from Google's infrastructure.

According to https://kubernetes.io/releases/download/ and https://www.downloadkubernetes.com/ the binaries are now reachable via dl.k8s.io.

The old endpoint on https://storage.googleapis.com/kubernetes-release/release/stable.txt is still reporting a current stable version of v1.31.0, while the most current kubectl according to https://dl.k8s.io/release/stable.txt is v1.36.0