### PR TITLE
fix: use chmod 755 instead of 777 for downloaded helm binary and folder

### DIFF
--- a/src/helm-util.test.ts
+++ b/src/helm-util.test.ts
@@ -112,7 +112,7 @@ describe('Testing all functions in helm-util file.', () => {
       expect(toolCache.find).toHaveBeenCalledWith('helm', 'v2.14.1')
       expect(fs.chmodSync).toHaveBeenCalledWith(
          path.join('pathToCachedDir', 'helm.exe'),
-         '777'
+         '755'
       )
    })
 
@@ -137,7 +137,7 @@ describe('Testing all functions in helm-util file.', () => {
       expect(toolCache.downloadTool).toHaveBeenCalledWith(
          'https://get.helm.sh/helm-v2.14.1-windows-amd64.zip'
       )
-      expect(fs.chmodSync).toHaveBeenCalledWith('pathToTool', '777')
+      expect(fs.chmodSync).toHaveBeenCalledWith('pathToTool', '755')
       expect(toolCache.extractZip).toHaveBeenCalledWith('pathToTool')
    })
 
@@ -168,11 +168,11 @@ describe('Testing all functions in helm-util file.', () => {
       expect(toolCache.downloadTool).toHaveBeenCalledWith(
          'https://get.helm.sh/helm-v4.0.0-windows-amd64.zip'
       )
-      expect(fs.chmodSync).toHaveBeenCalledWith('pathToTool', '777')
+      expect(fs.chmodSync).toHaveBeenCalledWith('pathToTool', '755')
       expect(toolCache.extractZip).toHaveBeenCalledWith('pathToTool')
       expect(fs.chmodSync).toHaveBeenCalledWith(
          path.join('pathToCachedDir', 'helm.exe'),
-         '777'
+         '755'
       )
    })
 
@@ -313,7 +313,7 @@ describe('Testing all functions in helm-util file.', () => {
       expect(helmUtil.findHelm('mainFolder')).toBe(
          path.join('mainFolder', 'helm.exe')
       )
-      expect(fs.chmodSync).toHaveBeenCalledWith('mainFolder', '777')
+      expect(fs.chmodSync).toHaveBeenCalledWith('mainFolder', '755')
       expect(fs.readdirSync).toHaveBeenCalledWith('mainFolder')
       expect(fs.statSync).toHaveBeenCalledWith(
          path.join('mainFolder', 'helm.exe')

--- a/src/helm-util.ts
+++ b/src/helm-util.ts
@@ -56,12 +56,12 @@ export async function downloadHelm(version: string): Promise<string> {
       )
    }
 
-   fs.chmodSync(helmpath, '777')
+   fs.chmodSync(helmpath, '755')
    return helmpath
 }
 
 export function findHelm(rootFolder: string): string {
-   fs.chmodSync(rootFolder, '777')
+   fs.chmodSync(rootFolder, '755')
    const filelist: string[] = []
    walkSync(rootFolder, filelist, helmToolName + getExecutableExtension())
    if (!filelist) {

--- a/src/kubectl-util.test.ts
+++ b/src/kubectl-util.test.ts
@@ -26,7 +26,7 @@ describe('Testing all functions in kubectl-util file.', () => {
       expect(os.type).toHaveBeenCalled()
       expect(fs.chmodSync).toHaveBeenCalledWith(
          path.join('pathToCachedTool', 'kubectl.exe'),
-         '777'
+         '755'
       )
    })
 
@@ -56,7 +56,7 @@ describe('Testing all functions in kubectl-util file.', () => {
       expect(os.type).toHaveBeenCalled()
       expect(fs.chmodSync).toHaveBeenCalledWith(
          path.join('pathToCachedTool', 'kubectl.exe'),
-         '777'
+         '755'
       )
    })
 
@@ -101,7 +101,7 @@ describe('Testing all functions in kubectl-util file.', () => {
       expect(os.type).toHaveBeenCalled()
       expect(fs.chmodSync).toHaveBeenCalledWith(
          path.join('pathToCachedTool', 'kubectl.exe'),
-         '777'
+         '755'
       )
    })
 

--- a/src/kubectl-util.ts
+++ b/src/kubectl-util.ts
@@ -31,7 +31,7 @@ export async function downloadKubectl(version: string): Promise<string> {
       cachedToolpath,
       kubectlToolName + getExecutableExtension()
    )
-   fs.chmodSync(kubectlPath, '777')
+   fs.chmodSync(kubectlPath, '755')
    return kubectlPath
 }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -74,7 +74,7 @@ export async function setCachedToolPath(toolName: string, version: string) {
    }
 
    if (toolName == 'helm') {
-      fs.chmodSync(downloadPath, '777')
+      fs.chmodSync(downloadPath, '755')
       const unzipedHelmPath = await toolCache.extractZip(downloadPath)
       cachedToolpath = await toolCache.cacheDir(
          unzipedHelmPath,


### PR DESCRIPTION
World-writable permissions allow other processes on shared runners to replace the helm binary with a malicious one between download and execution. Reduce to allow execute/read