### PR TITLE
feat(helm): add helm-dry-run input for server-side .Lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The `helm-version` input supports semver-compatible version ranges. This is usef
 - `v3.12.1` - Use an exact version
 - `latest` - Use the latest stable release (may include breaking changes across major versions)
 
+#### Server-side `.Lookup`
+
+Set `helm-dry-run` to `client` or `server` to pass `--dry-run=<mode>` to `helm template`. Use `server` when your chart calls `.Lookup` and needs to resolve against the cluster your runner is authenticated to. Requires Helm >= 3.13. Any data resolved via `.Lookup` (including Secret values) will be embedded in the rendered manifests bundle.
+
 #### Bake using Kompose
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
       description: 'Version of helm. Installs a specific version of helm binary. Supports semver ranges like ^3.0.0'
       required: false
       default: '^3.0.0'
+   helm-dry-run:
+      description: 'Relevant if renderEngine == helm. Passes --dry-run=<mode> to helm template so .Lookup can resolve against a live cluster. Accepted values: client, server. Requires Helm >= 3.13.'
+      required: false
    kubectl-version:
       description: 'Version of kubectl. Installs a specific version of kubectl binary'
       required: false

--- a/src/bake.test.ts
+++ b/src/bake.test.ts
@@ -545,4 +545,138 @@ describe('Test all functions in run file', () => {
          }
       }
    )
+
+   test.each<[string, string]>([
+      ['server', 'server-side dry-run'],
+      ['client', 'client-side dry-run']
+   ])(
+      'HelmRenderEngine() - helm-dry-run=%s (%s) appends --dry-run to template',
+      async (mode) => {
+         vi.spyOn(helmUtil, 'getHelmPath').mockResolvedValue('pathToHelm')
+         vi.spyOn(core, 'getInput').mockImplementation((inputName) => {
+            if (inputName === 'helmChart') return 'pathToHelmChart'
+            if (inputName === 'releaseName') return 'releaseName'
+            if (inputName === 'renderEngine') return 'helm'
+            if (inputName === 'helm-dry-run') return mode
+            return ''
+         })
+         vi.spyOn(console, 'log').mockImplementation(() => {})
+         process.env['RUNNER_TEMP'] = 'tempDirPath'
+         vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
+         vi.spyOn(utils, 'getCurrentTime').mockReturnValue(12345678)
+         vi.spyOn(core, 'setOutput').mockImplementation(() => {})
+
+         vi.spyOn(utils, 'execCommand').mockImplementation(
+            async (path, args) => {
+               if (args.includes('version')) {
+                  return {stdout: 'v3.13.0', stderr: '', code: 0}
+               }
+               return {stdout: 'template output', stderr: '', code: 0}
+            }
+         )
+
+         await new HelmRenderEngine().bake(true)
+
+         expect(utils.execCommand).toHaveBeenCalledWith(
+            'pathToHelm',
+            ['template', `--dry-run=${mode}`, 'releaseName', 'pathToHelmChart'],
+            {silent: true}
+         )
+      }
+   )
+
+   test('HelmRenderEngine() - omits --dry-run when helm-dry-run is unset', async () => {
+      vi.spyOn(helmUtil, 'getHelmPath').mockResolvedValue('pathToHelm')
+      vi.spyOn(core, 'getInput').mockImplementation((inputName) => {
+         if (inputName === 'helmChart') return 'pathToHelmChart'
+         if (inputName === 'releaseName') return 'releaseName'
+         if (inputName === 'renderEngine') return 'helm'
+         return ''
+      })
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      process.env['RUNNER_TEMP'] = 'tempDirPath'
+      vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
+      vi.spyOn(utils, 'getCurrentTime').mockReturnValue(12345678)
+      vi.spyOn(core, 'setOutput').mockImplementation(() => {})
+
+      vi.spyOn(utils, 'execCommand').mockImplementation(async (path, args) => {
+         if (args.includes('version')) {
+            return {stdout: 'v3.13.0', stderr: '', code: 0}
+         }
+         return {stdout: 'template output', stderr: '', code: 0}
+      })
+
+      await new HelmRenderEngine().bake(true)
+
+      const templateCalls = (utils.execCommand as any).mock.calls.filter(
+         (call: [string, string[], unknown]) =>
+            Array.isArray(call[1]) && call[1][0] === 'template'
+      )
+      expect(templateCalls.length).toBeGreaterThan(0)
+      for (const call of templateCalls) {
+         expect(
+            (call[1] as string[]).some((a) => a.startsWith('--dry-run'))
+         ).toBe(false)
+      }
+   })
+
+   test('HelmRenderEngine() - rejects invalid helm-dry-run value', async () => {
+      vi.spyOn(helmUtil, 'getHelmPath').mockResolvedValue('pathToHelm')
+      vi.spyOn(core, 'getInput').mockImplementation((inputName) => {
+         if (inputName === 'helmChart') return 'pathToHelmChart'
+         if (inputName === 'renderEngine') return 'helm'
+         if (inputName === 'helm-dry-run') return 'server; rm -rf /'
+         return ''
+      })
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      const execSpy = vi.spyOn(utils, 'execCommand')
+
+      await expect(new HelmRenderEngine().bake(true)).rejects.toThrow(
+         /Invalid value for helm-dry-run/
+      )
+      expect(execSpy).not.toHaveBeenCalled()
+   })
+
+   test('HelmRenderEngine() - rejects helm-dry-run on Helm < 3.13', async () => {
+      vi.spyOn(helmUtil, 'getHelmPath').mockResolvedValue('pathToHelm')
+      vi.spyOn(core, 'getInput').mockImplementation((inputName) => {
+         if (inputName === 'helmChart') return 'pathToHelmChart'
+         if (inputName === 'renderEngine') return 'helm'
+         if (inputName === 'helm-dry-run') return 'server'
+         return ''
+      })
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      vi.spyOn(utils, 'execCommand').mockImplementation(async (path, args) => {
+         if (args.includes('version')) {
+            return {stdout: 'v3.12.0', stderr: '', code: 0}
+         }
+         return {stdout: '', stderr: '', code: 0}
+      })
+
+      await expect(new HelmRenderEngine().bake(true)).rejects.toThrow(
+         /helm-dry-run requires Helm v3\.13 or newer/
+      )
+   })
+
+   test('HelmRenderEngine() - rejects helm-dry-run on Helm v2', async () => {
+      vi.spyOn(helmUtil, 'getHelmPath').mockResolvedValue('pathToHelm')
+      vi.spyOn(core, 'getInput').mockImplementation((inputName) => {
+         if (inputName === 'helmChart') return 'pathToHelmChart'
+         if (inputName === 'renderEngine') return 'helm'
+         if (inputName === 'helm-dry-run') return 'client'
+         return ''
+      })
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+      vi.spyOn(core, 'warning').mockImplementation(() => {})
+      vi.spyOn(utils, 'execCommand').mockImplementation(async (path, args) => {
+         if (args.includes('version')) {
+            return {stdout: 'v2.17.0', stderr: '', code: 0}
+         }
+         return {stdout: '', stderr: '', code: 0}
+      })
+
+      await expect(new HelmRenderEngine().bake(true)).rejects.toThrow(
+         /helm-dry-run requires Helm v3\.13 or newer/
+      )
+   })
 })

--- a/src/bake.ts
+++ b/src/bake.ts
@@ -12,6 +12,9 @@ import {getHelmPath, NameValuePair} from './helm-util.js'
 import {getKubectlPath} from './kubectl-util.js'
 import {getKomposePath} from './kompose-util.js'
 
+const HELM_DRY_RUN_MODES = ['client', 'server'] as const
+type HelmDryRunMode = (typeof HELM_DRY_RUN_MODES)[number]
+
 abstract class RenderEngine {
    public bake!: (isSilent: boolean) => Promise<any>
    protected getTemplatePath = () => {
@@ -32,6 +35,8 @@ export class HelmRenderEngine extends RenderEngine {
       const helmPath = await getHelmPath()
       const chartPath = core.getInput('helmChart', {required: true})
 
+      const dryRunMode = this.getDryRunMode()
+
       const options = {
          silent: isSilent
       } as ExecOptions
@@ -42,14 +47,22 @@ export class HelmRenderEngine extends RenderEngine {
       await utilities.execCommand(helmPath, dependencyArgs, options)
 
       console.log('Getting helm version..')
-      let isV3OrNewer = true
-      await this.isHelmV3OrNewer(helmPath)
-         .then((result) => {
-            isV3OrNewer = result
-         })
-         .catch(() => {
-            isV3OrNewer = false
-         })
+      const versionInfo = await this.getHelmVersionInfo(helmPath)
+      const isV3OrNewer = versionInfo !== null && versionInfo.major >= 3
+
+      if (
+         dryRunMode &&
+         (!versionInfo ||
+            versionInfo.major < 3 ||
+            (versionInfo.major === 3 && versionInfo.minor < 13))
+      ) {
+         const detected = versionInfo
+            ? `${versionInfo.major}.${versionInfo.minor}.${versionInfo.patch}`
+            : 'unknown'
+         throw new Error(
+            `helm-dry-run requires Helm v3.13 or newer. Detected: ${detected}.`
+         )
+      }
 
       try {
          if (!isV3OrNewer) {
@@ -69,7 +82,11 @@ export class HelmRenderEngine extends RenderEngine {
       }
 
       console.log('Creating the template argument string..')
-      const args = await this.getHelmTemplateArgs(chartPath, isV3OrNewer)
+      const args = await this.getHelmTemplateArgs(
+         chartPath,
+         isV3OrNewer,
+         dryRunMode
+      )
 
       console.log('Running helm template command..')
       const result = await utilities.execCommand(helmPath, args, options)
@@ -77,6 +94,19 @@ export class HelmRenderEngine extends RenderEngine {
       const pathToBakedManifest = this.getTemplatePath()
       fs.writeFileSync(pathToBakedManifest, result.stdout)
       core.setOutput('manifestsBundle', pathToBakedManifest)
+   }
+
+   private getDryRunMode(): HelmDryRunMode | undefined {
+      const raw = core.getInput('helm-dry-run', {required: false})
+      if (!raw) return undefined
+      if (!(HELM_DRY_RUN_MODES as readonly string[]).includes(raw)) {
+         throw new Error(
+            `Invalid value for helm-dry-run: "${raw}". Expected one of: ${HELM_DRY_RUN_MODES.join(
+               ', '
+            )}.`
+         )
+      }
+      return raw as HelmDryRunMode
    }
 
    private getOverrideValues(overrides: string[]) {
@@ -111,11 +141,15 @@ export class HelmRenderEngine extends RenderEngine {
 
    private async getHelmTemplateArgs(
       chartPath: string,
-      isV3OrNewer: boolean
+      isV3OrNewer: boolean,
+      dryRunMode?: HelmDryRunMode
    ): Promise<string[]> {
       const releaseName = core.getInput('releaseName', {required: false})
       let args: string[] = []
       args.push('template')
+      if (dryRunMode) {
+         args.push(`--dry-run=${dryRunMode}`)
+      }
       const templateArgs = await getTemplateArguments()
       args = args.concat(templateArgs)
 
@@ -166,19 +200,28 @@ export class HelmRenderEngine extends RenderEngine {
       return args
    }
 
-   private async isHelmV3OrNewer(path: string) {
-      let result = await utilities.execCommand(
-         path,
-         ['version', '--template', '{{.Version}}'],
-         {silent: true}
-      )
-      const versionPart = result.stdout.split('.')[0].replace('v', '')
-      const majorVersion = parseInt(versionPart, 10)
-      if (isNaN(majorVersion)) {
-         throw new Error(`Unable to parse Helm version from: ${result.stdout}`)
+   private async getHelmVersionInfo(
+      helmPath: string
+   ): Promise<{major: number; minor: number; patch: number} | null> {
+      try {
+         const result = await utilities.execCommand(
+            helmPath,
+            ['version', '--template', '{{.Version}}'],
+            {silent: true}
+         )
+         const match = result.stdout
+            .trim()
+            .replace(/^v/, '')
+            .match(/^(\d+)\.(\d+)\.(\d+)/)
+         if (!match) return null
+         return {
+            major: parseInt(match[1], 10),
+            minor: parseInt(match[2], 10),
+            patch: parseInt(match[3], 10)
+         }
+      } catch {
+         return null
       }
-      // Helm v3+ doesn't require init (Tiller was removed)
-      return majorVersion >= 3
    }
 }
 


### PR DESCRIPTION
Adds an opt-in helm-dry-run input (values: client, server) that appends --dry-run=<mode> to helm template. With server this lets charts using Helm's .Lookup template function resolve against the cluster the runner is authenticated to, avoiding brittle pre-step kubectl extraction.

Values are allowlisted before exec, and a version gate rejects the input on Helm < 3.13 (where helm template --dry-run first shipped). Default behavior is unchanged when the input is unset.

Closes #123