### PR TITLE
fix: write baked manifest into the workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ The `helm-version` input supports semver-compatible version ranges. This is usef
 
 Refer to the [action metadata file](https://github.com/Azure/k8s-bake/blob/master/action.yml) for details about all the inputs.
 
+## Output location
+
+The baked manifest is written to a `.k8s-bake` directory inside `GITHUB_WORKSPACE`, and its full path is exposed as the `manifestsBundle` output. The manifest is removed at the end of the job, along with the directory if nothing else is in it.
+
+Always consume the result through the output variable rather than hardcoding a path:
+
+```yaml
+manifests: ${{ steps.bake.outputs.manifestsBundle }}
+```
+
+If your workflow checks for an unmodified checkout part way through the job, add the directory to your `.gitignore`:
+
+```gitignore
+.k8s-bake/
+```
+
+> **Note.** Earlier versions wrote to `RUNNER_TEMP`, which sits outside `GITHUB_WORKSPACE`. `k8s-deploy` v7 rejects manifests that resolve outside the workspace, so bake output could no longer be deployed ([#286](https://github.com/Azure/k8s-bake/issues/286)). Workflows that read `manifestsBundle` need no changes.
+
 ## End to end workflow for building container images and deploying to a Kubernetes cluster
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -49,3 +49,4 @@ branding:
 runs:
    using: 'node24'
    main: 'lib/index.js'
+   post: 'lib/cleanup.js'

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,13 +1,23 @@
 import {build} from 'esbuild'
 
-await build({
-   entryPoints: ['src/run.ts'],
+const shared = {
    bundle: true,
    platform: 'node',
    target: 'node24',
    format: 'esm',
-   outfile: 'lib/index.js',
    banner: {
       js: "import {createRequire} from 'node:module'; const require = createRequire(import.meta.url);"
    }
+}
+
+await build({
+   ...shared,
+   entryPoints: ['src/run.ts'],
+   outfile: 'lib/index.js'
+})
+
+await build({
+   ...shared,
+   entryPoints: ['src/post.ts'],
+   outfile: 'lib/cleanup.js'
 })

--- a/src/bake.test.ts
+++ b/src/bake.test.ts
@@ -16,7 +16,18 @@ import * as core from '@actions/core'
 import {ExecOptions} from '@actions/exec'
 
 describe('Test all functions in run file', () => {
-   afterEach(() => vi.restoreAllMocks())
+   // These exercise the RUNNER_TEMP fallback, which only applies without a
+   // workspace. CI runs inside Actions where one is set, so clear it.
+   let savedWorkspace: string | undefined
+   beforeEach(() => {
+      savedWorkspace = process.env['GITHUB_WORKSPACE']
+      delete process.env['GITHUB_WORKSPACE']
+   })
+   afterEach(() => {
+      if (savedWorkspace === undefined) delete process.env['GITHUB_WORKSPACE']
+      else process.env['GITHUB_WORKSPACE'] = savedWorkspace
+      vi.restoreAllMocks()
+   })
 
    test("KustomizeRenderEngine() - throw error if kubectl doesn't meet required version", async () => {
       vi.spyOn(kubectlUtil, 'getKubectlPath').mockResolvedValue('pathToKubectl')
@@ -198,7 +209,7 @@ describe('Test all functions in run file', () => {
       )
    })
 
-   test('KomposeRenderEngine() - throw error if unable to find temp directory', async () => {
+   test('KomposeRenderEngine() - throw error if no output location can be determined', async () => {
       vi.spyOn(core, 'getInput').mockReturnValue('pathToKompose')
       vi.spyOn(ioUtil, 'exists').mockResolvedValue(true)
       vi.spyOn(komposeUtil, 'getKomposePath').mockResolvedValue('pathToKompose')
@@ -208,7 +219,7 @@ describe('Test all functions in run file', () => {
       vi.spyOn(console, 'log').mockImplementation(() => {})
 
       await expect(new KomposeRenderEngine().bake(false)).rejects.toThrow(
-         'Unable to create temp directory.'
+         'Unable to determine an output directory'
       )
       expect(komposeUtil.getKomposePath).toHaveBeenCalled()
    })
@@ -265,12 +276,10 @@ describe('Test all functions in run file', () => {
       vi.spyOn(core, 'setFailed').mockImplementation(() => {})
 
       await expect(run()).rejects.toThrow(
-         'Failed to run bake action. Error: Error: Unable to create temp directory.'
+         'Unable to determine an output directory'
       )
       expect(core.setFailed).toHaveBeenCalledWith(
-         expect.stringContaining(
-            'Failed to run bake action. Error: Error: Unable to create temp directory.'
-         )
+         expect.stringContaining('Unable to determine an output directory')
       )
    })
 

--- a/src/bake.ts
+++ b/src/bake.ts
@@ -12,19 +12,46 @@ import {getHelmPath, NameValuePair} from './helm-util.js'
 import {getKubectlPath} from './kubectl-util.js'
 import {getKomposePath} from './kompose-util.js'
 
+// Prefers $GITHUB_WORKSPACE/.k8s-bake/, falling back to $RUNNER_TEMP when there
+// is no workspace. k8s-deploy v7 rejects manifests resolving outside the
+// workspace, so RUNNER_TEMP output can no longer be deployed (#286).
+export function getBakedManifestPath(): string {
+   const fileName =
+      utilities.BAKED_MANIFEST_PREFIX +
+      utilities.getCurrentTime().toString() +
+      '.yaml'
+
+   const workspace = process.env['GITHUB_WORKSPACE']
+   if (!!workspace) {
+      const outputDirectory = path.join(
+         workspace,
+         utilities.BAKE_OUTPUT_DIRNAME
+      )
+      fs.mkdirSync(outputDirectory, {recursive: true})
+      // Filename, not path: mkdirSync succeeds whether or not the directory
+      // already existed, so bake owns only the file it writes.
+      core.saveState(utilities.CLEANUP_STATE_KEY, fileName)
+      return path.join(outputDirectory, fileName)
+   }
+
+   const tempDirectory = process.env['RUNNER_TEMP']
+   if (!!tempDirectory) {
+      core.warning(
+         'GITHUB_WORKSPACE is not set; writing the baked manifest to RUNNER_TEMP. ' +
+            'k8s-deploy v7 and newer reject manifests outside the workspace.'
+      )
+      return path.join(tempDirectory, fileName)
+   }
+
+   throw Error(
+      'Unable to determine an output directory. Run in an environment where ' +
+         'GITHUB_WORKSPACE or RUNNER_TEMP is set.'
+   )
+}
+
 abstract class RenderEngine {
    public bake!: (isSilent: boolean) => Promise<any>
-   protected getTemplatePath = () => {
-      const tempDirectory = process.env['RUNNER_TEMP']
-      if (!!tempDirectory) {
-         return path.join(
-            tempDirectory,
-            'baked-template-' + utilities.getCurrentTime().toString() + '.yaml'
-         )
-      } else {
-         throw Error('Unable to create temp directory.')
-      }
-   }
+   protected getTemplatePath = () => getBakedManifestPath()
 }
 
 export class HelmRenderEngine extends RenderEngine {

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as core from '@actions/core'
+import fs from 'fs'
+import path from 'path'
+import {
+   BAKE_OUTPUT_DIRNAME,
+   BAKED_MANIFEST_PATTERN,
+   CLEANUP_STATE_KEY
+} from './constants.js'
+
+// Removes the manifest bake wrote into the workspace. Deletes exactly the file
+// the main step recorded, then the directory only if that leaves it empty.
+//
+// The parent is recomputed from GITHUB_WORKSPACE rather than taken from state,
+// and the recorded name must be a bare filename matching the generated pattern,
+// so state cannot steer the delete outside the directory.
+export function cleanup() {
+   const recorded = core.getState(CLEANUP_STATE_KEY)
+   if (!recorded) {
+      core.debug('No baked manifest recorded; nothing to clean up.')
+      return
+   }
+   if (
+      path.basename(recorded) !== recorded ||
+      !BAKED_MANIFEST_PATTERN.test(recorded)
+   ) {
+      core.warning(
+         `Ignoring unexpected recorded manifest name "${recorded}"; skipping cleanup.`
+      )
+      return
+   }
+
+   const workspace = process.env['GITHUB_WORKSPACE']
+   if (!workspace) {
+      core.debug('GITHUB_WORKSPACE is not set; nothing to clean up.')
+      return
+   }
+
+   let directory: string
+   try {
+      const resolvedWorkspace = fs.realpathSync(path.resolve(workspace))
+      const candidate = path.join(resolvedWorkspace, BAKE_OUTPUT_DIRNAME)
+      if (!fs.existsSync(candidate)) {
+         core.debug(`No baked manifest directory at ${candidate}.`)
+         return
+      }
+
+      // Rejects a symlink planted at .k8s-bake pointing elsewhere.
+      directory = fs.realpathSync(candidate)
+      if (path.relative(resolvedWorkspace, directory) !== BAKE_OUTPUT_DIRNAME) {
+         core.warning(
+            `Refusing to clean ${candidate}: it resolves to ${directory}, outside the expected location.`
+         )
+         return
+      }
+      if (!fs.statSync(directory).isDirectory()) {
+         core.warning(`Refusing to clean ${directory}: not a directory.`)
+         return
+      }
+   } catch (err) {
+      core.warning(`Skipping cleanup of the baked manifest directory: ${err}`)
+      return
+   }
+
+   const file = path.join(directory, recorded)
+   try {
+      // lstat, not stat: never follow a symlink named like a manifest.
+      if (fs.existsSync(file)) {
+         if (fs.lstatSync(file).isFile()) {
+            fs.unlinkSync(file)
+            core.debug(`Removed baked manifest ${file}`)
+         } else {
+            core.warning(`Refusing to remove ${file}: not a regular file.`)
+         }
+      }
+   } catch (err) {
+      core.warning(`Failed to remove baked manifest ${file}: ${err}`)
+   }
+
+   // Non-recursive: fails rather than deleting anything bake did not write.
+   try {
+      fs.rmdirSync(directory)
+      core.debug(`Removed baked manifest directory ${directory}`)
+   } catch {
+      core.debug(`Leaving ${directory} in place; it is not empty.`)
+   }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Kept in a dedicated module so the post-job cleanup entry point does not have
+// to bundle utilities.ts and its dependencies just to read these.
+
+export const BAKE_OUTPUT_DIRNAME = '.k8s-bake'
+
+export const BAKED_MANIFEST_PREFIX = 'baked-template-'
+export const BAKED_MANIFEST_PATTERN = /^baked-template-\d+\.yaml$/
+
+// Filename the main step generated, read back by the post-job step. Stored as a
+// basename and re-validated on read, since step state travels as a STATE_*
+// environment variable.
+export const CLEANUP_STATE_KEY = 'bakedManifestFile'

--- a/src/output-location.test.ts
+++ b/src/output-location.test.ts
@@ -1,0 +1,282 @@
+import {vi} from 'vitest'
+import * as core from '@actions/core'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import * as utils from './utilities.js'
+import {getBakedManifestPath} from './bake.js'
+import {cleanup} from './cleanup.js'
+
+describe('getBakedManifestPath', () => {
+   let workspace: string
+   let runnerTemp: string
+   let savedWorkspace: string | undefined
+   let savedTemp: string | undefined
+
+   const FILENAME = 'baked-template-12345678.yaml'
+
+   beforeEach(() => {
+      savedWorkspace = process.env['GITHUB_WORKSPACE']
+      savedTemp = process.env['RUNNER_TEMP']
+      workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-'))
+      runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'rt-'))
+      process.env['GITHUB_WORKSPACE'] = workspace
+      process.env['RUNNER_TEMP'] = runnerTemp
+      vi.spyOn(utils, 'getCurrentTime').mockReturnValue(12345678)
+      vi.spyOn(core, 'getInput').mockReturnValue('')
+   })
+
+   afterEach(() => {
+      if (savedWorkspace === undefined) delete process.env['GITHUB_WORKSPACE']
+      else process.env['GITHUB_WORKSPACE'] = savedWorkspace
+      if (savedTemp === undefined) delete process.env['RUNNER_TEMP']
+      else process.env['RUNNER_TEMP'] = savedTemp
+      fs.rmSync(workspace, {recursive: true, force: true})
+      fs.rmSync(runnerTemp, {recursive: true, force: true})
+      vi.restoreAllMocks()
+   })
+
+   it('defaults to .k8s-bake inside the workspace', () => {
+      const result = getBakedManifestPath()
+      expect(result).toBe(
+         path.join(workspace, utils.BAKE_OUTPUT_DIRNAME, FILENAME)
+      )
+   })
+
+   it('creates the default output directory', () => {
+      getBakedManifestPath()
+      const dir = path.join(workspace, utils.BAKE_OUTPUT_DIRNAME)
+      expect(fs.existsSync(dir)).toBe(true)
+      expect(fs.statSync(dir).isDirectory()).toBe(true)
+   })
+
+   // k8s-deploy v7 rejects anything resolving outside GITHUB_WORKSPACE.
+   it('produces a path inside the workspace by default', () => {
+      const result = getBakedManifestPath()
+      const rel = path.relative(workspace, result)
+      expect(rel.startsWith('..')).toBe(false)
+      expect(path.isAbsolute(rel)).toBe(false)
+   })
+
+   it('records the generated filename, not a path', () => {
+      const result = getBakedManifestPath()
+      expect(core.saveState).toHaveBeenCalledWith(
+         utils.CLEANUP_STATE_KEY,
+         path.basename(result)
+      )
+      expect(utils.BAKED_MANIFEST_PATTERN.test(path.basename(result))).toBe(
+         true
+      )
+   })
+
+   it('falls back to RUNNER_TEMP when GITHUB_WORKSPACE is unset', () => {
+      delete process.env['GITHUB_WORKSPACE']
+      expect(getBakedManifestPath()).toBe(path.join(runnerTemp, FILENAME))
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining('GITHUB_WORKSPACE is not set')
+      )
+   })
+
+   it('records nothing when falling back to RUNNER_TEMP', () => {
+      delete process.env['GITHUB_WORKSPACE']
+      getBakedManifestPath()
+      expect(core.saveState).not.toHaveBeenCalled()
+   })
+
+   it('throws when neither workspace nor temp dir is available', () => {
+      delete process.env['GITHUB_WORKSPACE']
+      delete process.env['RUNNER_TEMP']
+      expect(() => getBakedManifestPath()).toThrow(
+         'Unable to determine an output directory'
+      )
+   })
+})
+
+describe('cleanup', () => {
+   let workspace: string
+   let outsider: string
+   let bakeDir: string
+   let savedWorkspace: string | undefined
+
+   const baked = (n: number) => `${utils.BAKED_MANIFEST_PREFIX}${n}.yaml`
+   const record = (name: string) =>
+      vi.spyOn(core, 'getState').mockReturnValue(name)
+
+   beforeEach(() => {
+      savedWorkspace = process.env['GITHUB_WORKSPACE']
+      workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-'))
+      outsider = fs.mkdtempSync(path.join(os.tmpdir(), 'outside-'))
+      bakeDir = path.join(workspace, utils.BAKE_OUTPUT_DIRNAME)
+      process.env['GITHUB_WORKSPACE'] = workspace
+   })
+
+   afterEach(() => {
+      // Restore before removing: one test mocks fs to throw.
+      vi.restoreAllMocks()
+      if (savedWorkspace === undefined) delete process.env['GITHUB_WORKSPACE']
+      else process.env['GITHUB_WORKSPACE'] = savedWorkspace
+      fs.rmSync(workspace, {recursive: true, force: true})
+      fs.rmSync(outsider, {recursive: true, force: true})
+   })
+
+   it('removes the recorded manifest and the now-empty directory', () => {
+      fs.mkdirSync(bakeDir)
+      fs.writeFileSync(path.join(bakeDir, baked(1)), 'kind: Service')
+      record(baked(1))
+      cleanup()
+      expect(fs.existsSync(bakeDir)).toBe(false)
+   })
+
+   // Bake records the one filename it generated.
+   it('preserves a pre-existing manifest it did not generate', () => {
+      fs.mkdirSync(bakeDir)
+      const theirs = path.join(bakeDir, baked(123))
+      const ours = path.join(bakeDir, baked(456))
+      fs.writeFileSync(theirs, 'not mine')
+      fs.writeFileSync(ours, 'kind: Service')
+      record(baked(456))
+
+      cleanup()
+
+      expect(fs.readFileSync(theirs, 'utf8')).toBe('not mine')
+      expect(fs.existsSync(ours)).toBe(false)
+      expect(fs.existsSync(bakeDir)).toBe(true)
+   })
+
+   // post.ts runs even when the main step failed before generating anything.
+   it('does nothing when no manifest was recorded', () => {
+      fs.mkdirSync(bakeDir)
+      const theirs = path.join(bakeDir, baked(123))
+      fs.writeFileSync(theirs, 'not mine')
+      record('')
+
+      cleanup()
+
+      expect(fs.readFileSync(theirs, 'utf8')).toBe('not mine')
+      expect(fs.existsSync(bakeDir)).toBe(true)
+   })
+
+   it('removes an empty directory when the manifest was never written', () => {
+      fs.mkdirSync(bakeDir)
+      record(baked(1))
+      cleanup()
+      expect(fs.existsSync(bakeDir)).toBe(false)
+   })
+
+   it('preserves a pre-existing user file and keeps the directory', () => {
+      fs.mkdirSync(bakeDir)
+      const userFile = path.join(bakeDir, 'user-file.txt')
+      fs.writeFileSync(userFile, 'mine')
+      fs.writeFileSync(path.join(bakeDir, baked(1)), 'kind: Service')
+      record(baked(1))
+
+      cleanup()
+
+      expect(fs.readFileSync(userFile, 'utf8')).toBe('mine')
+      expect(fs.existsSync(path.join(bakeDir, baked(1)))).toBe(false)
+      expect(fs.existsSync(bakeDir)).toBe(true)
+   })
+
+   it('preserves a user subdirectory', () => {
+      fs.mkdirSync(bakeDir)
+      fs.mkdirSync(path.join(bakeDir, 'nested'))
+      fs.writeFileSync(path.join(bakeDir, 'nested', 'keep.yaml'), 'kind: X')
+      record(baked(1))
+      cleanup()
+      expect(fs.existsSync(path.join(bakeDir, 'nested', 'keep.yaml'))).toBe(
+         true
+      )
+   })
+
+   it('does nothing when the directory is absent', () => {
+      record(baked(1))
+      expect(() => cleanup()).not.toThrow()
+   })
+
+   // State travels as a STATE_* env var, so the recorded name is untrusted.
+   it.each([
+      ['traversal', '../../../etc/passwd'],
+      ['absolute path', '/etc/passwd'],
+      ['nested path', 'sub/baked-template-1.yaml'],
+      ['traversal with valid basename', `../${'baked-template-1.yaml'}`],
+      ['non-matching name', 'user-file.txt'],
+      ['near miss', 'baked-template-abc.yaml']
+   ])('rejects a recorded name with %s', (_label, value) => {
+      fs.mkdirSync(bakeDir)
+      const victim = path.join(outsider, 'data.txt')
+      fs.writeFileSync(victim, 'do not delete')
+      fs.writeFileSync(path.join(bakeDir, 'user-file.txt'), 'mine')
+      record(value)
+
+      cleanup()
+
+      expect(fs.existsSync(victim)).toBe(true)
+      expect(fs.existsSync(path.join(bakeDir, 'user-file.txt'))).toBe(true)
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining('Ignoring unexpected recorded manifest name')
+      )
+   })
+
+   it('refuses to follow a symlink planted at .k8s-bake', () => {
+      const victim = path.join(outsider, 'precious')
+      fs.mkdirSync(victim)
+      fs.writeFileSync(path.join(victim, baked(1)), 'do not delete')
+      fs.symlinkSync(victim, bakeDir)
+      record(baked(1))
+
+      cleanup()
+
+      expect(fs.existsSync(path.join(victim, baked(1)))).toBe(true)
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining('outside the expected location')
+      )
+   })
+
+   // A symlink named like a manifest must not delete its target.
+   it('does not follow a symlink named like a baked manifest', () => {
+      fs.mkdirSync(bakeDir)
+      const victim = path.join(outsider, 'data.txt')
+      fs.writeFileSync(victim, 'do not delete')
+      fs.symlinkSync(victim, path.join(bakeDir, baked(1)))
+      record(baked(1))
+
+      cleanup()
+
+      expect(fs.existsSync(victim)).toBe(true)
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining('not a regular file')
+      )
+   })
+
+   it('refuses to act on a plain file at .k8s-bake', () => {
+      fs.writeFileSync(bakeDir, 'not a directory')
+      record(baked(1))
+      cleanup()
+      expect(fs.existsSync(bakeDir)).toBe(true)
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining('not a directory')
+      )
+   })
+
+   it('skips when GITHUB_WORKSPACE is unset', () => {
+      fs.mkdirSync(bakeDir)
+      fs.writeFileSync(path.join(bakeDir, baked(1)), 'kind: Service')
+      record(baked(1))
+      delete process.env['GITHUB_WORKSPACE']
+      cleanup()
+      expect(fs.existsSync(bakeDir)).toBe(true)
+   })
+
+   it('warns rather than failing the job when the delete fails', () => {
+      fs.mkdirSync(bakeDir)
+      fs.writeFileSync(path.join(bakeDir, baked(1)), 'kind: Service')
+      record(baked(1))
+      vi.spyOn(fs, 'unlinkSync').mockImplementation(() => {
+         throw new Error('EPERM')
+      })
+      expect(() => cleanup()).not.toThrow()
+      expect(core.warning).toHaveBeenCalledWith(
+         expect.stringContaining('Failed to remove baked manifest')
+      )
+   })
+})

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,0 +1,3 @@
+import {cleanup} from './cleanup.js'
+
+cleanup()

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -6,7 +6,9 @@ vi.mock('@actions/core', () => ({
    setFailed: vi.fn(),
    warning: vi.fn(),
    debug: vi.fn(),
-   info: vi.fn()
+   info: vi.fn(),
+   saveState: vi.fn(),
+   getState: vi.fn()
 }))
 
 vi.mock('@actions/tool-cache', () => ({

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -181,6 +181,13 @@ const downloadLinks: Record<string, Record<string, string>> = {
 export const LATEST = 'latest'
 export const MIN_KUBECTL_CLIENT_VERSION = '1.14'
 
+export {
+   BAKE_OUTPUT_DIRNAME,
+   BAKED_MANIFEST_PREFIX,
+   BAKED_MANIFEST_PATTERN,
+   CLEANUP_STATE_KEY
+} from './constants.js'
+
 const helmReleasesUrl = 'https://api.github.com/repos/helm/helm/releases'
 
 export interface HelmRelease {


### PR DESCRIPTION
Fixes #286

## Problem

`k8s-deploy` v7 rejects manifests that resolve outside `GITHUB_WORKSPACE`. Bake writes to `RUNNER_TEMP`, which is a sibling of the workspace on hosted runners, so the bake -> deploy chain fails and there is no way to override the location.

```
/home/runner/work/
├── _temp/        <- bake output
└── my-repo/
    └── my-repo/  <- GITHUB_WORKSPACE
```

## Change

Output goes to `$GITHUB_WORKSPACE/.k8s-bake/`, falling back to `RUNNER_TEMP` with a warning when there is no workspace. A post-job step removes the manifest it generated, and the directory if that leaves it empty.

Applies to all three render engines through the shared `getTemplatePath` hook.

**Breaking:** the output location changes. Workflows reading `${{ steps.bake.outputs.manifestsBundle }}` need no changes. `k8s-deploy` needs no changes.

## Notes

Cleanup deletes only the filename the main step recorded, never a path from step state, and refuses symlinks. A pre-existing `.k8s-bake` directory or unrelated files in it are left alone.

## Test plan

- [x] `npm test`, 119 tests
- [x] `npm run build`, `tsc --noEmit`, `prettier --check`
- [x] End to end with the built bundle: output lands in the workspace, `RUNNER_TEMP` stays empty, post step leaves the checkout clean
- [x] Baked output accepted by unmodified `k8s-deploy` v7
- [x] Two bake steps in one job: each removes its own manifest, last one removes the directory
- [x] Pre-existing `.k8s-bake/user-file.txt` and `.k8s-bake/baked-template-123.yaml` survive cleanup

Version bump and changelog follow in a separate release PR.
