### PR TITLE
chore: enforce 7-day dependency freshness period + signed commit check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,28 @@ updates:
    - package-ecosystem: npm
      directory: /
      schedule:
-        interval: weekly
+        interval: cron
+        cronjob: '0 8 1,15 * *'
+     cooldown:
+        default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch
    - package-ecosystem: github-actions
      directory: .github/workflows
      schedule:
-        interval: weekly
+        interval: cron
+        cronjob: '0 8 1,15 * *'
+     cooldown:
+        default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch

--- a/.github/workflows/check-signed-commits.yml
+++ b/.github/workflows/check-signed-commits.yml
@@ -1,0 +1,12 @@
+name: Check Signed Commits
+
+on:
+   pull_request:
+
+permissions:
+   contents: read
+   pull-requests: write
+
+jobs:
+   signed:
+      uses: Azure/action-release-workflows/.github/workflows/check_signed_commits.yaml@2ff084415c5af591fd13d95ddbfc4cdb5ed2012e

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/README.md
+++ b/README.md
@@ -128,6 +128,27 @@ jobs:
                  demo-k8s-secret
 ```
 
+# Development
+
+This repository enforces a **7-day dependency freshness ("bake") period**: newly
+published npm packages are not adopted until they have been available for at
+least 7 days, giving the ecosystem time to catch broken or malicious releases.
+
+- **Dependabot** uses a 7-day `cooldown` and opens PRs on the 1st and 15th of
+  each month, grouping minor/patch updates into a single PR. Major updates are
+  still raised individually so they get their own review.
+- **`.npmrc`** sets `min-release-age=7` (days), which applies the same rule to
+  local `npm install`. This requires npm >= 11.10.0; the version bundled with
+  Node 24 (this action's runtime) satisfies that. On older npm the setting is
+  ignored, so Dependabot's `cooldown` remains the authoritative control.
+
+**Security exception:** to adopt an urgent patch that is less than 7 days old,
+install it once with the age check disabled:
+
+```sh
+npm install <pkg> --min-release-age=0
+```
+
 # Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a


### PR DESCRIPTION
Brings k8s-bake in line with the dependency-freshness standardization rolling out across the action repos. Today this repo has **no** cooldown at all — dependabot is on plain `weekly` with a single group matching `*`.

### Dependency freshness (4 mechanisms)

| | before | after |
|---|---|---|
| dependabot `cooldown` | none | `default-days: 7` |
| schedule | `weekly` | cron `0 8 1,15 * *` |
| grouping | one `*` group (majors lumped in) | `minor-and-patch` group; majors raised individually |
| local installs | unconstrained | `.npmrc` `min-release-age=7` |

Newly published packages aren't adopted until they've been out at least 7 days, giving the ecosystem time to catch broken or malicious releases.

**Deliberately omitted:** an `engines.npm >= 11.10.0` + `engine-strict` guard. Node 24 — this action's runtime (`runs.using: node24`) — bundles npm 11.17, so the gate would only ever fire for a contributor already off the target runtime, at the cost of hard-failing their `npm install`. Dependabot's `cooldown` enforces the bake server-side regardless of anyone's local npm, so `min-release-age` is defense-in-depth on a path that goes through review anyway.

### Signed commit check

Adds `check-signed-commits.yml` calling the shared `check_signed_commits.yaml` reusable workflow.

- Pinned to `2ff0844` — the same action-release-workflows SHA already used by `release-pr.yml`, and currently identical to that repo's `main`. Preferred over `@main` since this workflow runs with write access to PR comments.
- Caller sets `contents: read` / `pull-requests: write` explicitly rather than relying on the repo's default token permissions, which the reusable workflow needs in order to post its findings.

Verified: build, 119/119 tests, prettier all pass. Lockfile untouched (136/136 sha512, registry.npmjs.org only).