### PR TITLE
docs: refresh action versions in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sets output variable 'manifestsBundle' which contains the location of the manife
 #### Bake using helm
 
 ```yaml
-- uses: azure/k8s-bake@v3
+- uses: azure/k8s-bake@v4
    with:
       renderEngine: 'helm'
       helmChart: './aks-helloworld/'
@@ -37,7 +37,7 @@ The `helm-version` input supports semver-compatible version ranges. This is usef
 #### Bake using Kompose
 
 ```yaml
-- uses: azure/k8s-bake@v3
+- uses: azure/k8s-bake@v4
   with:
      renderEngine: 'kompose'
      dockerComposeFile: './docker-compose.yml'
@@ -47,7 +47,7 @@ The `helm-version` input supports semver-compatible version ranges. This is usef
 #### Bake using Kubernetes Kustomize
 
 ```yaml
-- uses: azure/k8s-bake@v3
+- uses: azure/k8s-bake@v4
   with:
      renderEngine: 'kustomize'
      kustomizationPath: './kustomizeexample/'
@@ -57,7 +57,7 @@ The `helm-version` input supports semver-compatible version ranges. This is usef
      kubectl-version: 'latest'
 ```
 
-Refer to the [action metadata file](https://github.com/Azure/k8s-bake/blob/master/action.yml) for details about all the inputs.
+Refer to the [action metadata file](https://github.com/Azure/k8s-bake/blob/main/action.yml) for details about all the inputs.
 
 ## Output location
 
@@ -86,9 +86,9 @@ jobs:
    build:
       runs-on: ubuntu-latest
       steps:
-         - uses: actions/checkout@master
+         - uses: actions/checkout@v7
 
-         - uses: Azure/docker-login@v1
+         - uses: Azure/docker-login@v2
            with:
               login-server: contoso.azurecr.io
               username: ${{ secrets.REGISTRY_USERNAME }}
@@ -98,18 +98,18 @@ jobs:
               docker build . -t contoso.azurecr.io/k8sdemo:${{ github.sha }}
               docker push contoso.azurecr.io/k8sdemo:${{ github.sha }}
 
-         - uses: Azure/k8s-set-context@v3
+         - uses: Azure/k8s-set-context@v5
            with:
               kubeconfig: ${{ secrets.KUBE_CONFIG }}
 
-         - uses: Azure/k8s-create-secret@v4
+         - uses: Azure/k8s-create-secret@v6
            with:
               container-registry-url: contoso.azurecr.io
               container-registry-username: ${{ secrets.REGISTRY_USERNAME }}
               container-registry-password: ${{ secrets.REGISTRY_PASSWORD }}
               secret-name: demo-k8s-secret
 
-         - uses: azure/k8s-bake@v3
+         - uses: azure/k8s-bake@v4
            with:
               renderEngine: 'helm'
               helmChart: './aks-helloworld/'
@@ -119,7 +119,7 @@ jobs:
               helm-version: 'latest'
            id: bake
 
-         - uses: Azure/k8s-deploy@v4
+         - uses: Azure/k8s-deploy@v7
            with:
               manifests: ${{ steps.bake.outputs.manifestsBundle }}
               images: |


### PR DESCRIPTION
## Problem

Every README example pins actions one to three majors behind. Two are actively misleading rather than merely stale:

**`actions/checkout@master`** — `master` is a *real branch* in `actions/checkout`, not a redirect to `main`. It is frozen at `61b9e375` (2020-07-13), while `main` is at 2026. The end-to-end example therefore instructs users to run six-year-old checkout code.

**`Azure/k8s-deploy@v4`** paired with bake output no longer reflects reality. Since k8s-deploy v7 confines `manifests:` to `GITHUB_WORKSPACE` and bake v4.1.1 writes there (#289), the example should show the combination that actually works together.

## Changes

| Action | Before | After |
|---|---|---|
| `azure/k8s-bake` (4 examples) | `@v3` | `@v4` |
| `actions/checkout` | `@master` | `@v7` |
| `Azure/docker-login` | `@v1` | `@v2` |
| `Azure/k8s-set-context` | `@v3` | `@v5` |
| `Azure/k8s-create-secret` | `@v4` | `@v6` |
| `Azure/k8s-deploy` | `@v4` | `@v7` |

Also repointed the action-metadata link from `blob/master/action.yml` to `blob/main/action.yml` — the old URL only worked via a 302.

## Verification

Since these are cross-major bumps, I checked that every input used in the examples still exists at the new major, so the snippets stay runnable:

- `k8s-set-context@v5` — `kubeconfig` present. `method` defaults to `kubeconfig` and `cluster-type` to `generic`, so the kubeconfig-only snippet is unchanged in behavior.
- `k8s-create-secret@v6` — `container-registry-url` / `-username` / `-password`, `secret-name` all present.
- `docker-login@v2` — `login-server`, `username`, `password` present.
- `k8s-deploy@v7` — `manifests`, `images`, `imagepullsecrets` present; `action` and `strategy` are required but defaulted, so the snippet needs no new keys.

I also confirmed each floating major tag is current rather than stale — e.g. `azure/k8s-bake@v4` is an annotated tag dereferencing to `bf8bfd3` (v4.1.1), and `checkout@v7` → `3d3c42e` (v7.0.1).

## Test plan

- [x] `prettier --check README.md` passes
- [x] No residual `@v3` / `@master` / old-major references remain
- [x] Docs-only; no `src/`, `action.yml`, or workflow changes